### PR TITLE
Apply white-list to tag or property names retrieved from IoTHub while rebuilding the device group filter cache

### DIFF
--- a/Services.Test/CacheTest.cs
+++ b/Services.Test/CacheTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services;
@@ -11,70 +12,304 @@ using Microsoft.Azure.IoTSolutions.UIConfig.Services.Models;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Runtime;
 using Moq;
 using Newtonsoft.Json;
+using Services.Test.helpers;
 using Xunit;
 
 namespace Services.Test
 {
     public class CacheTest
     {
-        private readonly Mock<IStorageAdapterClient> mockStorageAdapterClient;
-        private readonly Mock<IIothubManagerServiceClient> mockIothubManagerClient;
-        private readonly Mock<ISimulationServiceClient> mockSimulationClient;
-        private readonly Mock<IServicesConfig> config;
-        private readonly Mock<ILogger> log;
-        private readonly Cache cache;
-        private readonly string cacheModel = null;
-
-        public CacheTest()
-        {
-            this.cacheModel = JsonConvert.SerializeObject(new CacheValue
-            {
-                Rebuilding = false,
-                Tags = new HashSet<string> { "c", "a", "y", "z" },
-                Reported = new HashSet<string> { "1", "9", "2", "3" }
-            });
-            this.mockStorageAdapterClient = new Mock<IStorageAdapterClient>();
-            this.mockIothubManagerClient = new Mock<IIothubManagerServiceClient>();
-            this.mockSimulationClient = new Mock<ISimulationServiceClient>();
-            this.log = new Mock<ILogger>();
-            this.log.Setup(m => m.Info(It.IsAny<string>(), It.IsAny<Action>())).Callback(() => { });
-            this.log.Setup(m => m.Info(It.IsAny<string>(), It.IsAny<Func<object>>())).Callback(() => { });
-            this.log.Setup(m => m.Debug(It.IsAny<string>(), It.IsAny<Action>())).Callback(() => { });
-            this.log.Setup(m => m.Debug(It.IsAny<string>(), It.IsAny<Func<object>>())).Callback(() => { });
-            this.log.Setup(m => m.Error(It.IsAny<string>(), It.IsAny<Action>())).Callback(() => { });
-            this.log.Setup(m => m.Error(It.IsAny<string>(), It.IsAny<Func<object>>())).Callback(() => { });
-            this.config = new Mock<IServicesConfig>();
-            this.config.SetupGet(m => m.CacheTTL).Returns(3600);
-            this.config.SetupGet(m => m.CacheRebuildTimeout).Returns(20);
-            this.cache = new Cache(this.mockStorageAdapterClient.Object, this.mockIothubManagerClient.Object, this.mockSimulationClient.Object, this.config.Object, this.log.Object);
-        }
+        private Random rand = new Random();
 
         [Fact]
         public async Task GetCacheAsyncTestAsync()
         {
-            this.mockStorageAdapterClient.Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(new ValueApiModel { Data = this.cacheModel }));
-            var result = await this.cache.GetCacheAsync();
-            Assert.Equal(string.Join(",", (new string[] { "c", "a", "y", "z" }).OrderBy(m => m)),
-                string.Join(",", result.Tags.OrderBy(m => m))
-            );
-            Assert.Equal(string.Join(",", (new string[] { "1", "9", "2", "3" }).OrderBy(m => m)),
-                string.Join(",", result.Reported.OrderBy(m => m))
-            );
+            var mockStorageAdapterClient = new Mock<IStorageAdapterClient>();
+
+            var cache = new Cache(
+                mockStorageAdapterClient.Object,
+                new Mock<IIothubManagerServiceClient>().Object,
+                new Mock<ISimulationServiceClient>().Object,
+                new ServicesConfig(),
+                new Logger("UnitTest", LogLevel.Debug));
+
+            var cacheValue = new CacheValue
+            {
+                Rebuilding = false,
+                Tags = new HashSet<string> { "c", "a", "y", "z" },
+                Reported = new HashSet<string> { "1", "9", "2", "3" }
+            };
+
+            mockStorageAdapterClient
+                .Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(() => Task.FromResult(new ValueApiModel { Data = JsonConvert.SerializeObject(cacheValue) }));
+
+            var result = await cache.GetCacheAsync();
+
+            Assert.True(result.Tags.OrderBy(m => m).SequenceEqual(cacheValue.Tags.OrderBy(m => m)));
+            Assert.True(result.Reported.OrderBy(m => m).SequenceEqual(cacheValue.Reported.OrderBy(m => m)));
         }
 
         [Fact]
         public async Task SetCacheAsyncTest()
         {
-            this.mockStorageAdapterClient.Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(new ValueApiModel { Data = this.cacheModel }));
-            CacheValue model = new CacheValue { Tags = new HashSet<string> { "c", "a", "y", "z", "@", "#" }, Reported = new HashSet<string> { "1", "9", "2", "3", "12", "11" }, Rebuilding = false };
-            this.mockStorageAdapterClient.Setup(m => m.UpdateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(new ValueApiModel { Data = JsonConvert.SerializeObject(model) }));
-            var result = await this.cache.SetCacheAsync(new CacheValue { Tags = new HashSet<string> { "a", "y", "z", "@", "#" }, Reported = new HashSet<string> { "9", "2", "3", "11", "12" } });
-            Assert.Equal(string.Join(",", (new string[] { "c", "a", "y", "z", "@", "#" }).OrderBy(m => m)),
-                string.Join(",", result.Tags.OrderBy(m => m))
-            );
-            Assert.Equal(string.Join(",", (new string[] { "1", "9", "2", "3", "12", "11" }).OrderBy(m => m)),
-                string.Join(",", result.Reported.OrderBy(m => m))
-            );
+            var mockStorageAdapterClient = new Mock<IStorageAdapterClient>();
+
+            var cache = new Cache(
+                mockStorageAdapterClient.Object,
+                new Mock<IIothubManagerServiceClient>().Object,
+                new Mock<ISimulationServiceClient>().Object,
+                new ServicesConfig(),
+                new Logger("UnitTest", LogLevel.Debug));
+
+            var oldCacheValue = new CacheValue
+            {
+                Rebuilding = false,
+                Tags = new HashSet<string> { "c", "a", "y", "z" },
+                Reported = new HashSet<string> { "1", "9", "2", "3" }
+            };
+
+            var cachePatch = new CacheValue
+            {
+                Tags = new HashSet<string> { "a", "y", "z", "@", "#" },
+                Reported = new HashSet<string> { "9", "2", "3", "11", "12" }
+            };
+
+            var newCacheValue = new CacheValue
+            {
+                Tags = new HashSet<string> { "c", "a", "y", "z", "@", "#" },
+                Reported = new HashSet<string> { "1", "9", "2", "3", "12", "11" }
+            };
+
+            mockStorageAdapterClient
+                .Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(() => Task.FromResult(new ValueApiModel { Data = JsonConvert.SerializeObject(oldCacheValue) }));
+
+            mockStorageAdapterClient
+                .Setup(m => m.UpdateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(() => Task.FromResult(new ValueApiModel { Data = JsonConvert.SerializeObject(newCacheValue) }));
+
+            var result = await cache.SetCacheAsync(cachePatch);
+
+            Assert.True(result.Tags.SetEquals(newCacheValue.Tags));
+            Assert.True(result.Reported.SetEquals(newCacheValue.Reported));
+        }
+
+        [Fact]
+        public async Task RebuildCacheAsyncSkipByTimeTest()
+        {
+            var mockStorageAdapterClient = new Mock<IStorageAdapterClient>();
+
+            var cache = new Cache(
+                mockStorageAdapterClient.Object,
+                new Mock<IIothubManagerServiceClient>().Object,
+                new Mock<ISimulationServiceClient>().Object,
+                new ServicesConfig
+                {
+                    CacheTTL = 60
+                },
+                new Logger("UnitTest", LogLevel.Debug));
+
+            mockStorageAdapterClient
+                .Setup(x => x.GetAsync(
+                    It.Is<string>(s => s == Cache.CACHE_COLLECTION_ID),
+                    It.Is<string>(s => s == Cache.CACHE_KEY)))
+                .ReturnsAsync(new ValueApiModel
+                {
+                    ETag = this.rand.NextString(),
+                    Data = JsonConvert.SerializeObject(new CacheValue
+                    {
+                        Rebuilding = false
+                    }),
+                    Metadata = new Dictionary<string, string>
+                    {
+                        { "$modified", DateTimeOffset.UtcNow.ToString(CultureInfo.InvariantCulture) }
+                    }
+                });
+
+            var result = await cache.RebuildCacheAsync();
+            Assert.False(result);
+
+            mockStorageAdapterClient
+                .Verify(x => x.GetAsync(
+                    It.Is<string>(s => s == Cache.CACHE_COLLECTION_ID),
+                    It.Is<string>(s => s == Cache.CACHE_KEY)),
+                    Times.Once);
+        }
+
+        [Fact]
+        public async Task RebuildCacheAsyncSkipByConflictTest()
+        {
+            var mockStorageAdapterClient = new Mock<IStorageAdapterClient>();
+
+            var cache = new Cache(
+                mockStorageAdapterClient.Object,
+                new Mock<IIothubManagerServiceClient>().Object,
+                new Mock<ISimulationServiceClient>().Object,
+                new ServicesConfig
+                {
+                    CacheTTL = 10,
+                    CacheRebuildTimeout = 300
+                },
+                new Logger("UnitTest", LogLevel.Debug));
+
+            mockStorageAdapterClient
+                .Setup(x => x.GetAsync(
+                    It.Is<string>(s => s == Cache.CACHE_COLLECTION_ID),
+                    It.Is<string>(s => s == Cache.CACHE_KEY)))
+                .ReturnsAsync(new ValueApiModel
+                {
+                    ETag = this.rand.NextString(),
+                    Data = JsonConvert.SerializeObject(new CacheValue
+                    {
+                        Rebuilding = true
+                    }),
+                    Metadata = new Dictionary<string, string>
+                    {
+                        { "$modified", (DateTimeOffset.UtcNow - TimeSpan.FromMinutes(1)).ToString(CultureInfo.InvariantCulture) }
+                    }
+                });
+
+            var result = await cache.RebuildCacheAsync();
+            Assert.False(result);
+
+            mockStorageAdapterClient
+                .Verify(x => x.GetAsync(
+                        It.Is<string>(s => s == Cache.CACHE_COLLECTION_ID),
+                        It.Is<string>(s => s == Cache.CACHE_KEY)),
+                    Times.Once);
+        }
+
+        [Fact]
+        public async Task RebuildCacheAsyncTest()
+        {
+            var mockStorageAdapterClient = new Mock<IStorageAdapterClient>();
+            var mockIothubManagerClient = new Mock<IIothubManagerServiceClient>();
+            var mockSimulationServiceClient = new Mock<ISimulationServiceClient>();
+
+            var cache = new Cache(
+                mockStorageAdapterClient.Object,
+                mockIothubManagerClient.Object,
+                mockSimulationServiceClient.Object,
+                new ServicesConfig
+                {
+                    CacheWhiteList = "tags.*, reported.Type, reported.Config.*",
+                    CacheTTL = 3600
+                },
+                new Logger("UnitTest", LogLevel.Debug));
+
+            var etagOld = this.rand.NextString();
+            var etagLock = this.rand.NextString();
+            var etagNew = this.rand.NextString();
+
+            mockStorageAdapterClient
+                .Setup(x => x.GetAsync(
+                    It.Is<string>(s => s == Cache.CACHE_COLLECTION_ID),
+                    It.Is<string>(s => s == Cache.CACHE_KEY)))
+                .ReturnsAsync(new ValueApiModel
+                {
+                    ETag = etagOld,
+                    Data = JsonConvert.SerializeObject(new CacheValue
+                    {
+                        Rebuilding = false
+                    }),
+                    Metadata = new Dictionary<string, string>
+                    {
+                        { "$modified", (DateTimeOffset.UtcNow - TimeSpan.FromDays(1)).ToString(CultureInfo.InvariantCulture) }
+                    }
+                });
+
+            mockIothubManagerClient
+                .Setup(x => x.GetDeviceTwinNamesAsync())
+                .ReturnsAsync(new DeviceTwinName
+                {
+                    Tags = new HashSet<string> { "Building", "Group" },
+                    ReportedProperties = new HashSet<string> { "Config.Interval", "otherProperty" }
+                });
+
+            mockSimulationServiceClient
+                .Setup(x => x.GetDevicePropertyNamesAsync())
+                .ReturnsAsync(new HashSet<string>
+                {
+                    "MethodStatus", "UpdateStatus"
+                });
+
+            mockStorageAdapterClient
+                .Setup(x => x.UpdateAsync(
+                    It.Is<string>(s => s == Cache.CACHE_COLLECTION_ID),
+                    It.Is<string>(s => s == Cache.CACHE_KEY),
+                    It.Is<string>(s => Rebuilding(s)),
+                    It.Is<string>(s => s == etagOld)))
+                .ReturnsAsync(new ValueApiModel
+                {
+                    ETag = etagLock
+                });
+
+            mockStorageAdapterClient
+                .Setup(x => x.UpdateAsync(
+                    It.Is<string>(s => s == Cache.CACHE_COLLECTION_ID),
+                    It.Is<string>(s => s == Cache.CACHE_KEY),
+                    It.Is<string>(s => !Rebuilding(s)),
+                    It.Is<string>(s => s == etagLock)))
+                .ReturnsAsync(new ValueApiModel
+                {
+                    ETag = etagNew
+                });
+
+            var expiredNames = new DeviceTwinName
+            {
+                Tags = new HashSet<string>
+                {
+                    "Building", "Group"
+                },
+                ReportedProperties = new HashSet<string>
+                {
+                    "Type", "Config.Interval", "MethodStatus", "UpdateStatus"
+                }
+            };
+
+            var result = await cache.RebuildCacheAsync();
+            Assert.True(result);
+
+            mockStorageAdapterClient
+                .Verify(x => x.GetAsync(
+                    It.Is<string>(s => s == Cache.CACHE_COLLECTION_ID),
+                    It.Is<string>(s => s == Cache.CACHE_KEY)),
+                    Times.Once);
+
+            mockIothubManagerClient
+                .Verify(x => x.GetDeviceTwinNamesAsync(), Times.Once);
+
+            mockSimulationServiceClient
+                .Verify(x => x.GetDevicePropertyNamesAsync(), Times.Once);
+
+            mockStorageAdapterClient
+                .Verify(x => x.UpdateAsync(
+                    It.Is<string>(s => s == Cache.CACHE_COLLECTION_ID),
+                    It.Is<string>(s => s == Cache.CACHE_KEY),
+                    It.Is<string>(s => Rebuilding(s)),
+                    It.Is<string>(s => s == etagOld)),
+                    Times.Once);
+
+            mockStorageAdapterClient
+                .Verify(x => x.UpdateAsync(
+                    It.Is<string>(s => s == Cache.CACHE_COLLECTION_ID),
+                    It.Is<string>(s => s == Cache.CACHE_KEY),
+                    It.Is<string>(s => !Rebuilding(s) && CheckNames(s, expiredNames)),
+                    It.Is<string>(s => s == etagLock)),
+                    Times.Once);
+        }
+
+        private static bool Rebuilding(string data)
+        {
+            return JsonConvert.DeserializeObject<CacheValue>(data).Rebuilding;
+        }
+
+        private static bool CheckNames(string data, DeviceTwinName expiredNames)
+        {
+            var cacheValue = JsonConvert.DeserializeObject<CacheValue>(data);
+            return cacheValue.Tags.SetEquals(expiredNames.Tags)
+                   && cacheValue.Reported.SetEquals(expiredNames.ReportedProperties);
         }
     }
 }

--- a/Services.Test/CacheTest.cs
+++ b/Services.Test/CacheTest.cs
@@ -96,7 +96,7 @@ namespace Services.Test
         }
 
         [Fact]
-        public async Task RebuildCacheAsyncSkipByTimeTest()
+        public async Task TryRebuildCacheAsyncSkipByTimeTest()
         {
             var mockStorageAdapterClient = new Mock<IStorageAdapterClient>();
 
@@ -127,7 +127,7 @@ namespace Services.Test
                     }
                 });
 
-            var result = await cache.RebuildCacheAsync();
+            var result = await cache.TryRebuildCacheAsync();
             Assert.False(result);
 
             mockStorageAdapterClient
@@ -138,7 +138,7 @@ namespace Services.Test
         }
 
         [Fact]
-        public async Task RebuildCacheAsyncSkipByConflictTest()
+        public async Task TryRebuildCacheAsyncSkipByConflictTest()
         {
             var mockStorageAdapterClient = new Mock<IStorageAdapterClient>();
 
@@ -170,7 +170,7 @@ namespace Services.Test
                     }
                 });
 
-            var result = await cache.RebuildCacheAsync();
+            var result = await cache.TryRebuildCacheAsync();
             Assert.False(result);
 
             mockStorageAdapterClient
@@ -181,7 +181,7 @@ namespace Services.Test
         }
 
         [Fact]
-        public async Task RebuildCacheAsyncTest()
+        public async Task TryRebuildCacheAsyncTest()
         {
             var mockStorageAdapterClient = new Mock<IStorageAdapterClient>();
             var mockIothubManagerClient = new Mock<IIothubManagerServiceClient>();
@@ -268,7 +268,7 @@ namespace Services.Test
                 }
             };
 
-            var result = await cache.RebuildCacheAsync();
+            var result = await cache.TryRebuildCacheAsync();
             Assert.True(result);
 
             mockStorageAdapterClient

--- a/Services.Test/SimulationServiceClientTest.cs
+++ b/Services.Test/SimulationServiceClientTest.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using Microsoft.Azure.IoTSolutions.UIConfig.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.External;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Http;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Runtime;
 using Moq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Services.Test
@@ -26,8 +25,7 @@ namespace Services.Test
                 new ServicesConfig
                 {
                     DeviceSimulationApiUrl = MOCK_SERVICE_URI
-                },
-                new Logger("UnitTest", LogLevel.Debug));
+                });
         }
 
         [Fact]
@@ -37,45 +35,45 @@ namespace Services.Test
             {
                 StatusCode = HttpStatusCode.OK,
                 IsSuccessStatusCode = true,
-                Content = @"{
-                              ""Items"": [
-                                {
-                                  ""key"": ""value"",
-                                  ""Properties"": {
-                                    ""Type"": ""Truck"",
-                                    ""Location"": ""Field"",
-                                    ""address"": {
-                                      ""street"": ""ssss"",
-                                      ""NO"": ""1111""
-                                    },
-                                    ""Latitude"": 47.445301,
-                                    ""Longitude"": -122.296307
-                                  }
+                Content = JsonConvert.SerializeObject(new
+                {
+                    Items = new object[] {
+                        new {
+                            key = "value",
+                            Properties = new {
+                                @Type = "Truck",
+                                Location = "Field",
+                                address = new {
+                                    street = "ssss",
+                                    NO = "1111"
                                 },
-                                {
-                            
-                                  ""Properties"": {
-                                    ""Type1"": ""Truck"",
-                                    ""Location"": ""Field"",
-                                    ""address1"": {
-                                      ""street"": ""ssss"",
-                                      ""NO"": ""1111""
-                                    },
-                                    ""Latitude1"": 47.445301,
-                                    ""Longitude"": -122.296307
-                                  }
-                                }
-                              ]
-                            }"
+                                Latitude = 47.445301,
+                                Longitude = -122.296307
+                            },
+                        },
+                        new {
+                            Properties = new {
+                                Type1 = "Truck",
+                                Location = "Field",
+                                address1 = new {
+                                    street = "ssss",
+                                    NO = "1111"
+                                },
+                                Latitude1 = 47.445301,
+                                Longitude = -122.296307
+                            }
+                        }
+                    }
+                })
             };
 
             this.mockHttpClient
                 .Setup(x => x.GetAsync(It.IsAny<IHttpRequest>()))
                 .ReturnsAsync(response);
 
-            var result = string.Join(",", (await this.client.GetDevicePropertyNamesAsync()).OrderBy(m => m));
+            var result = await this.client.GetDevicePropertyNamesAsync();
 
-            Assert.Equal(result, string.Join(",", (new string[] { "address.NO", "address.street", "address1.NO", "address1.street", "Type", "Location", "Latitude", "Longitude", "Type1", "Latitude1" }).OrderBy(m => m)));
+            Assert.True(result.SetEquals(new[] { "address.NO", "address.street", "address1.NO", "address1.street", "Type", "Location", "Latitude", "Longitude", "Type1", "Latitude1" }));
         }
     }
 }

--- a/Services.Test/StorageTest.cs
+++ b/Services.Test/StorageTest.cs
@@ -20,7 +20,6 @@ namespace Services.Test
     {
         private readonly string bingMapKey;
         private readonly Mock<IStorageAdapterClient> mockClient;
-        private readonly ServicesConfig config;
         private readonly Storage storage;
         private readonly Random rand;
 
@@ -30,8 +29,12 @@ namespace Services.Test
 
             this.bingMapKey = this.rand.NextString();
             this.mockClient = new Mock<IStorageAdapterClient>();
-            this.config = new ServicesConfig { BingMapKey = this.bingMapKey };
-            this.storage = new Storage(this.mockClient.Object, this.config);
+            this.storage = new Storage(
+                this.mockClient.Object,
+                new ServicesConfig
+                {
+                    BingMapKey = this.bingMapKey
+                });
         }
 
         [Fact]

--- a/Services.Test/StorageWriteLockTest.cs
+++ b/Services.Test/StorageWriteLockTest.cs
@@ -1,0 +1,326 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.IoTSolutions.UIConfig.Services.Exceptions;
+using Microsoft.Azure.IoTSolutions.UIConfig.Services.External;
+using Microsoft.Azure.IoTSolutions.UIConfig.Services.Helpers;
+using Moq;
+using Newtonsoft.Json;
+using Services.Test.helpers;
+using Xunit;
+
+namespace Services.Test
+{
+    public class StorageWriteLockTest
+    {
+        private const string COLL = "coll";
+        private const string KEY = "key";
+        private readonly Random rand;
+        private readonly Mock<IStorageAdapterClient> mockClient;
+
+        private class ValueModel
+        {
+            public string Value { get; set; }
+            public bool Locked { get; set; }
+        }
+
+        public StorageWriteLockTest()
+        {
+            this.rand = new Random();
+
+            this.mockClient = new Mock<IStorageAdapterClient>();
+        }
+
+        [Fact]
+        public async Task NormalLoopTest()
+        {
+            var etagOriginal = this.rand.NextString();
+            var etagLocked = this.rand.NextString();
+            var etagUpdated = this.rand.NextString();
+
+            var model = new ValueModel
+            {
+                Value = this.rand.NextString()
+            };
+
+            model.Locked = false;
+            var dataOriginal = JsonConvert.SerializeObject(model);
+
+            model.Locked = true;
+            var dataLocked = JsonConvert.SerializeObject(model);
+
+            model.Value = this.rand.NextString();
+            model.Locked = false;
+            var dataUpdated = JsonConvert.SerializeObject(model);
+
+            var @lock = new StorageWriteLock<ValueModel>(
+                this.mockClient.Object,
+                COLL,
+                KEY,
+                (v, b) => v.Locked = b,
+                m => !JsonConvert.DeserializeObject<ValueModel>(m.Data).Locked);
+
+            this.mockClient
+                .Setup(x => x.GetAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY)))
+                .ReturnsAsync(new ValueApiModel
+                {
+                    Data = dataOriginal,
+                    ETag = etagOriginal
+                });
+
+            this.mockClient
+                .Setup(x => x.UpdateAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY),
+                    It.Is<string>(s => s == dataLocked),
+                    It.Is<string>(s => s == etagOriginal)))
+                .ReturnsAsync(new ValueApiModel
+                {
+                    ETag = etagLocked
+                });
+
+            var lockResult = await @lock.TryLockAsync();
+            Assert.True(lockResult.Value);
+
+            this.mockClient
+                .Verify(x => x.GetAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY)),
+                    Times.Once);
+
+            this.mockClient
+                .Verify(x => x.GetAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY)),
+                    Times.Once);
+
+            this.mockClient
+                .Verify(x => x.UpdateAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY),
+                    It.Is<string>(s => s == dataLocked),
+                    It.Is<string>(s => s == etagOriginal)),
+                    Times.Once);
+
+            this.mockClient
+                .Setup(x => x.UpdateAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY),
+                    It.Is<string>(s => s == dataUpdated),
+                    It.Is<string>(s => s == etagLocked)))
+                .ReturnsAsync(new ValueApiModel
+                {
+                    ETag = etagUpdated
+                });
+
+            var writeResult = await @lock.WriteAndReleaseAsync(model);
+            Assert.True(writeResult);
+
+            this.mockClient
+                .Verify(x => x.UpdateAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY),
+                    It.Is<string>(s => s == dataUpdated),
+                    It.Is<string>(s => s == etagLocked)),
+                    Times.Once);
+        }
+
+        [Fact]
+        public async Task LockFailTest()
+        {
+            var etagOriginal = this.rand.NextString();
+
+            var model = new ValueModel
+            {
+                Value = this.rand.NextString()
+            };
+
+            model.Locked = true;
+            var dataOriginal = JsonConvert.SerializeObject(model);
+
+            var @lock = new StorageWriteLock<ValueModel>(
+                this.mockClient.Object,
+                COLL,
+                KEY,
+                (v, b) => v.Locked = b,
+                m => !JsonConvert.DeserializeObject<ValueModel>(m.Data).Locked);
+
+            this.mockClient
+                .Setup(x => x.GetAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY)))
+                .ReturnsAsync(new ValueApiModel
+                {
+                    Data = dataOriginal,
+                    ETag = etagOriginal
+                });
+
+            var result = await @lock.TryLockAsync();
+            Assert.False(result.Value);
+        }
+
+        [Fact]
+        public async Task LockConflictTest()
+        {
+            var etagOriginal = this.rand.NextString();
+
+            var model = new ValueModel
+            {
+                Value = this.rand.NextString()
+            };
+
+            model.Locked = false;
+            var dataOriginal = JsonConvert.SerializeObject(model);
+
+            model.Locked = true;
+            var dataLocked = JsonConvert.SerializeObject(model);
+
+            var @lock = new StorageWriteLock<ValueModel>(
+                this.mockClient.Object,
+                COLL,
+                KEY,
+                (v, b) => v.Locked = b,
+                m => !JsonConvert.DeserializeObject<ValueModel>(m.Data).Locked);
+
+            this.mockClient
+                .Setup(x => x.GetAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY)))
+                .ReturnsAsync(new ValueApiModel
+                {
+                    Data = dataOriginal,
+                    ETag = etagOriginal
+                });
+
+            this.mockClient
+                .Setup(x => x.UpdateAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY),
+                    It.Is<string>(s => s == dataLocked),
+                    It.Is<string>(s => s == etagOriginal)))
+                .ThrowsAsync(new ConflictingResourceException());
+
+            var result = await @lock.TryLockAsync();
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task WriteConflictTest()
+        {
+            var etagOriginal = this.rand.NextString();
+            var etagLocked = this.rand.NextString();
+
+            var model = new ValueModel
+            {
+                Value = this.rand.NextString()
+            };
+
+            model.Locked = false;
+            var dataOriginal = JsonConvert.SerializeObject(model);
+
+            model.Locked = true;
+            var dataLocked = JsonConvert.SerializeObject(model);
+
+            model.Value = this.rand.NextString();
+            model.Locked = false;
+            var dataUpdated = JsonConvert.SerializeObject(model);
+
+            var @lock = new StorageWriteLock<ValueModel>(
+                this.mockClient.Object,
+                COLL,
+                KEY,
+                (v, b) => v.Locked = b,
+                m => !JsonConvert.DeserializeObject<ValueModel>(m.Data).Locked);
+
+            this.mockClient
+                .Setup(x => x.GetAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY)))
+                .ReturnsAsync(new ValueApiModel
+                {
+                    Data = dataOriginal,
+                    ETag = etagOriginal
+                });
+
+            this.mockClient
+                .Setup(x => x.UpdateAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY),
+                    It.Is<string>(s => s == dataLocked),
+                    It.Is<string>(s => s == etagOriginal)))
+                .ReturnsAsync(new ValueApiModel
+                {
+                    ETag = etagLocked
+                });
+
+            var lockResult = await @lock.TryLockAsync();
+            Assert.True(lockResult.Value);
+
+            this.mockClient
+                .Verify(x => x.GetAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY)),
+                    Times.Once);
+
+            this.mockClient
+                .Verify(x => x.GetAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY)),
+                    Times.Once);
+
+            this.mockClient
+                .Verify(x => x.UpdateAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY),
+                    It.Is<string>(s => s == dataLocked),
+                    It.Is<string>(s => s == etagOriginal)),
+                    Times.Once);
+
+            this.mockClient
+                .Setup(x => x.UpdateAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY),
+                    It.Is<string>(s => s == dataUpdated),
+                    It.Is<string>(s => s == etagLocked)))
+                .ThrowsAsync(new ConflictingResourceException());
+
+            var writeResult = await @lock.WriteAndReleaseAsync(model);
+            Assert.False(writeResult);
+
+            this.mockClient
+                .Verify(x => x.UpdateAsync(
+                    It.Is<string>(s => s == COLL),
+                    It.Is<string>(s => s == KEY),
+                    It.Is<string>(s => s == dataUpdated),
+                    It.Is<string>(s => s == etagLocked)),
+                    Times.Once);
+        }
+
+        [Fact]
+        public async Task ReleaseAsyncWithoutLockTest()
+        {
+            var @lock = new StorageWriteLock<ValueModel>(
+                this.mockClient.Object,
+                COLL,
+                KEY,
+                (v, b) => v.Locked = b,
+                m => true);
+
+            await Assert.ThrowsAsync<ResourceOutOfDateException>(() => @lock.ReleaseAsync());
+        }
+
+        [Fact]
+        public async Task ReleaseAndWriteAsyncWithoutLockTest()
+        {
+            var @lock = new StorageWriteLock<ValueModel>(
+                this.mockClient.Object,
+                COLL,
+                KEY,
+                (v, b) => v.Locked = b,
+                m => true);
+
+            await Assert.ThrowsAsync<ResourceOutOfDateException>(() => @lock.WriteAndReleaseAsync(null));
+        }
+    }
+}

--- a/Services.Test/helpers/HashsetExtension.cs
+++ b/Services.Test/helpers/HashsetExtension.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Services.Test.helpers
+{
+    public static class HashsetExtension
+    {
+        public static bool SetEquals<T>(this HashSet<T> me, IEnumerable<T> other)
+        {
+            return me.IsSubsetOf(other) && me.IsSupersetOf(other);
+        }
+    }
+}

--- a/Services/External/DeviceModelListApiModel.cs
+++ b/Services/External/DeviceModelListApiModel.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.External
         {
             if (this.Items?.Count > 0)
             {
-                HashSet<string> set = new HashSet<string>();
+                var set = new HashSet<string>();
                 this.Items.ForEach(m =>
                 {
                     foreach (var item in m.Properties)
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.External
                 });
                 return set;
             }
+
             return null;
         }
 
@@ -35,15 +36,16 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.External
                 set.Add(prefix);
                 return;
             }
-            double outValue;
-            if (obj is bool || obj is string || double.TryParse(obj.ToString(), out outValue))
+
+            if (obj is bool || obj is string || double.TryParse(obj.ToString(), out _))
             {
                 set.Add(prefix);
                 return;
             }
+
             foreach (var item in (obj as JToken).Values())
             {
-                string path = item.Path;
+                var path = item.Path;
                 this.PreparePropNames(set, item, $"{prefix}.{(path.Contains(".") ? path.Substring(path.LastIndexOf('.') + 1) : path)}");
             }
         }

--- a/Services/External/IothubManagerServiceClient.cs
+++ b/Services/External/IothubManagerServiceClient.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Threading.Tasks;
-using Microsoft.Azure.IoTSolutions.UIConfig.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Http;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Models;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Runtime;
@@ -12,13 +11,11 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.External
     public class IothubManagerServiceClient : IIothubManagerServiceClient
     {
         private readonly IHttpClient httpClient;
-        private readonly ILogger log;
         private readonly string serviceUri;
 
-        public IothubManagerServiceClient(IHttpClient httpClient, IServicesConfig config, ILogger logger)
+        public IothubManagerServiceClient(IHttpClient httpClient, IServicesConfig config)
         {
             this.httpClient = httpClient;
-            this.log = logger;
             this.serviceUri = config.HubManagerApiUrl;
         }
 

--- a/Services/External/SimulationServiceClient.cs
+++ b/Services/External/SimulationServiceClient.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.IoTSolutions.UIConfig.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Http;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Runtime;
 using Newtonsoft.Json;
@@ -12,13 +11,11 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.External
     public class SimulationServiceClient : ISimulationServiceClient
     {
         private readonly IHttpClient httpClient;
-        private readonly ILogger log;
         private readonly string serviceUri;
 
-        public SimulationServiceClient(IHttpClient httpClient, IServicesConfig config, ILogger logger)
+        public SimulationServiceClient(IHttpClient httpClient, IServicesConfig config)
         {
             this.httpClient = httpClient;
-            this.log = logger;
             this.serviceUri = config.DeviceSimulationApiUrl;
         }
 
@@ -30,8 +27,10 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.External
             {
                 request.Options.AllowInsecureSSLServer = true;
             }
+
             var response = await this.httpClient.GetAsync(request);
-            DeviceModelListApiModel content = JsonConvert.DeserializeObject<DeviceModelListApiModel>(response.Content);
+
+            var content = JsonConvert.DeserializeObject<DeviceModelListApiModel>(response.Content);
             return content.GetPropNames();
         }
     }

--- a/Services/Helpers/StorageMutex.cs
+++ b/Services/Helpers/StorageMutex.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Exceptions;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.External;
 
-namespace Microsoft.Azure.IoTSolutions.UIConfig.Services
+namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.Helpers
 {
     public interface IStorageMutex
     {
@@ -38,8 +38,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services
                     // The motivation of timeout check is to recovery from stale state due to instance crash
                     if (Convert.ToBoolean(model.Data))
                     {
-                        DateTimeOffset lastModified;
-                        if (model.Metadata.ContainsKey(LAST_MODIFIED_KEY) && DateTimeOffset.TryParse(model.Metadata[LAST_MODIFIED_KEY], out lastModified))
+                        if (model.Metadata.ContainsKey(LAST_MODIFIED_KEY) && DateTimeOffset.TryParse(model.Metadata[LAST_MODIFIED_KEY], out var lastModified))
                         {
                             lastModified = DateTimeOffset.MinValue;
                         }

--- a/Services/Helpers/StorageWriteLock.cs
+++ b/Services/Helpers/StorageWriteLock.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.IoTSolutions.UIConfig.Services.Exceptions;
+using Microsoft.Azure.IoTSolutions.UIConfig.Services.External;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.Helpers
+{
+    public class StorageWriteLock<T> where T : class, new()
+    {
+        private readonly string collectionId;
+        private readonly string key;
+        private readonly IStorageAdapterClient client;
+        private readonly Action<T, bool> setLockFlagAction;
+        private readonly Func<ValueApiModel, bool> testLockFunc;
+
+        private T lastValue;
+        private string lastETag;
+
+        public StorageWriteLock(
+            IStorageAdapterClient client,
+            string collectionId,
+            string key,
+            Action<T, bool> setLockFlagAction,
+            Func<ValueApiModel, bool> testLockFunc)
+        {
+            this.client = client;
+            this.collectionId = collectionId;
+            this.key = key;
+            this.setLockFlagAction = setLockFlagAction;
+            this.testLockFunc = testLockFunc;
+
+            this.lastETag = null;
+        }
+
+        public async Task<bool?> TryLockAsync()
+        {
+            if (this.lastETag != null)
+            {
+                throw new ResourceOutOfDateException("Lock has already been acquired");
+            }
+
+            ValueApiModel model = null;
+
+            try
+            {
+                model = await this.client.GetAsync(this.collectionId, this.key);
+            }
+            catch (ResourceNotFoundException)
+            {
+                // Nothing to do
+            }
+
+            if (!this.testLockFunc(model))
+            {
+                return false;
+            }
+
+            this.lastValue = model == null ? new T() : JsonConvert.DeserializeObject<T>(model.Data);
+            this.setLockFlagAction(this.lastValue, true);
+
+            try
+            {
+                this.lastETag = await this.UpdateValueAsync(this.lastValue, model?.ETag);
+            }
+            catch (ConflictingResourceException)
+            {
+                return null;
+            }
+
+            return true;
+        }
+
+        public async Task ReleaseAsync()
+        {
+            if (this.lastETag == null)
+            {
+                throw new ResourceOutOfDateException("Lock was not acquired yet");
+            }
+
+            this.setLockFlagAction(this.lastValue, false);
+
+            try
+            {
+                await this.UpdateValueAsync(this.lastValue, this.lastETag);
+            }
+            catch (ConflictingResourceException)
+            {
+                // Nothing to do
+            }
+
+            this.lastETag = null;
+        }
+
+        public async Task<bool> WriteAndReleaseAsync(T newValue)
+        {
+            if (this.lastETag == null)
+            {
+                throw new ResourceOutOfDateException("Lock was not acquired yet");
+            }
+
+            this.setLockFlagAction(newValue, false);
+
+            try
+            {
+                await this.UpdateValueAsync(newValue, this.lastETag);
+            }
+            catch (ConflictingResourceException)
+            {
+                return false;
+            }
+
+            this.lastETag = null;
+            return true;
+        }
+
+        private async Task<string> UpdateValueAsync(T value, string etag)
+        {
+            var model = await this.client.UpdateAsync(
+                this.collectionId,
+                this.key,
+                JsonConvert.SerializeObject(value),
+                etag);
+
+            return model.ETag;
+        }
+    }
+}

--- a/Services/Runtime/ServicesConfig.cs
+++ b/Services/Runtime/ServicesConfig.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.Runtime
         string TelemetryApiUrl { get; }
         string HubManagerApiUrl { get; }
         string SeedTemplate { get; }
+        string CacheWhiteList { get; }
         // ReSharper disable once InconsistentNaming
         long CacheTTL { get; }
         long CacheRebuildTimeout { get; }
@@ -22,6 +23,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.Runtime
         public string TelemetryApiUrl { get; set; }
         public string HubManagerApiUrl { get; set; }
         public string SeedTemplate { get; set; }
+        public string CacheWhiteList { get; set; }
         public long CacheTTL { get; set; }
         public long CacheRebuildTimeout { get; set; }
         public string BingMapKey { get; set; }

--- a/Services/Seed.cs
+++ b/Services/Seed.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Exceptions;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.External;
+using Microsoft.Azure.IoTSolutions.UIConfig.Services.Helpers;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Models;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Runtime;
 using Newtonsoft.Json;

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Runtime
         private const string APPLICATION_KEY = "ConfigService:";
         private const string PORT_KEY = APPLICATION_KEY + "webservice_port";
         private const string SEED_TEMPLATE_KEY = APPLICATION_KEY + "seedTemplate";
+        private const string CACHE_WHITELIST_KEY = APPLICATION_KEY + "cache_whitelist";
         private const string CACHE_TTL_KEY = APPLICATION_KEY + "cache_TTL";
         private const string CACHE_REBUILD_TIMEOUT_KEY = APPLICATION_KEY + "rebuild_timeout";
         private const string BING_MAP_KEY_KEY = APPLICATION_KEY + "bingmap_key";
@@ -66,6 +67,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.Runtime
                 TelemetryApiUrl = configData.GetString(TELEMETRY_URL_KEY),
                 HubManagerApiUrl = configData.GetString(IOTHUB_MANAGER_URL_KEY),
                 SeedTemplate = configData.GetString(SEED_TEMPLATE_KEY),
+                CacheWhiteList = configData.GetString(CACHE_WHITELIST_KEY),
                 CacheTTL = configData.GetInt(CACHE_TTL_KEY),
                 CacheRebuildTimeout = configData.GetInt(CACHE_REBUILD_TIMEOUT_KEY),
                 BingMapKey = configData.GetString(BING_MAP_KEY_KEY)

--- a/WebService/Startup.cs
+++ b/WebService/Startup.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService
             await Task.Delay(TimeSpan.FromMinutes(5));
 
             var cache = this.ApplicationContainer.Resolve<ICache>();
-            await cache.RebuildCacheAsync();
+            await cache.TryRebuildCacheAsync();
         }
     }
 }

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -1,9 +1,10 @@
 [ConfigService]
 webservice_port = 9005
 seedTemplate = "default"
-cache_TTL=3600
-rebuild_timeout=20
-bingmap_key="${PCS_BINGMAP_KEY}"
+cache_whitelist = "tags.*, reported.Protocol, reported.SupportedMethods, reported.DeviceMethodStatus, reported.FirmwareUpdateStatus"
+cache_TTL = 3600
+rebuild_timeout = 20
+bingmap_key = "${PCS_BINGMAP_KEY}"
 
 
 [StorageAdapterService]

--- a/WebService/v1/Controllers/DeviceGroupFiltersController.cs
+++ b/WebService/v1/Controllers/DeviceGroupFiltersController.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.WebService.v1.Controllers
         [DepressedFilter]
         public async Task<ActionResult> RebuildAsync()
         {
-            await this.cache.RebuildCacheAsync(true);
+            await this.cache.TryRebuildCacheAsync(true);
             return this.Ok();
         }
     }


### PR DESCRIPTION
# Types of changes

<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

<!-- Please put an `x` (e.g. [x]) in all the boxes that apply: -->

- [x] The code follows the code style and conventions of this project.
- [x] All new and existing tests passed.
- [ ] The change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

# Description of the change

<!-- Please provide enough information so others can review your pull request -->

The service will query IoTHub for tag and property names while rebuilding the device group filter cache. In this code change, we are going to apply a white-list to hide unexpected names.

The white-list was specified in the configuration item `cache_whitelist` of `appsetting.ini`, in form of `"<item1>, <item2>, <item3>, ..."`. Wildcard (`*`) at the end of item means allow all names start with the specified prefix.

_Additional change: refine code style according code scan warnings_

# Motivation

Per Tim's request: "Investigate and Prune the reported properties returned – some reported properties look weird – are we pulling metadata when we don’t need to?"
