### PR TITLE
Retry forever for OnStart actions (Seed and RebuildCache) to remove the restriction on services startup order

### DIFF
--- a/Services/Helpers/StorageMutex.cs
+++ b/Services/Helpers/StorageMutex.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.Helpers
                     {
                         if (model.Metadata.ContainsKey(LAST_MODIFIED_KEY) && DateTimeOffset.TryParse(model.Metadata[LAST_MODIFIED_KEY], out var lastModified))
                         {
+                            // Timestamp retrieved successfully, nothing to do
+                        }
+                        else
+                        {
+                            // Treat it as timeout if the timestamp could not be retrieved
                             lastModified = DateTimeOffset.MinValue;
                         }
 
@@ -51,6 +56,7 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.Helpers
                 }
                 catch (ResourceNotFoundException)
                 {
+                    // Mutex is not initialized, treat it as released
                 }
 
                 try

--- a/Services/Helpers/StorageMutex.cs
+++ b/Services/Helpers/StorageMutex.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Azure.IoTSolutions.UIConfig.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.Exceptions;
 using Microsoft.Azure.IoTSolutions.UIConfig.Services.External;
 
@@ -17,10 +18,14 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.Helpers
     {
         private const string LAST_MODIFIED_KEY = "$modified";
         private readonly IStorageAdapterClient storageClient;
+        private readonly ILogger logger;
 
-        public StorageMutex(IStorageAdapterClient storageClient)
+        public StorageMutex(
+            IStorageAdapterClient storageClient,
+            ILogger logger)
         {
             this.storageClient = storageClient;
+            this.logger = logger;
         }
 
         public async Task<bool> EnterAsync(string collectionId, string key, TimeSpan timeout)
@@ -41,11 +46,13 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.Helpers
                         if (model.Metadata.ContainsKey(LAST_MODIFIED_KEY) && DateTimeOffset.TryParse(model.Metadata[LAST_MODIFIED_KEY], out var lastModified))
                         {
                             // Timestamp retrieved successfully, nothing to do
+                            this.logger.Info($"Mutex {collectionId}.{key} was occupied. Last modified = {lastModified}", () => { });
                         }
                         else
                         {
                             // Treat it as timeout if the timestamp could not be retrieved
                             lastModified = DateTimeOffset.MinValue;
+                            this.logger.Info("Mutex {collectionId}.{key} was occupied. Last modified could not be retrieved", () => { });
                         }
 
                         if (DateTimeOffset.UtcNow < lastModified + timeout)
@@ -53,10 +60,15 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services.Helpers
                             return false;
                         }
                     }
+                    else
+                    {
+                        this.logger.Info($"Mutex {collectionId}.{key} was NOT occupied", () => { });
+                    }
                 }
                 catch (ResourceNotFoundException)
                 {
                     // Mutex is not initialized, treat it as released
+                    this.logger.Info($"Mutex {collectionId}.{key} was not found", () => { });
                 }
 
                 try


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
While being deployed with Kubernates (without the `dependsOn` feature which supported only in docker), the Seed feature will failed because it could not resolve the underlying service host name at the beginning. Here we are going to add logic to try it forever, regardless any exception raised, to ensure the Seed and RebuildCache actions will be invoked.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

Additional fix: Use DateTimeOffset.MinValue when mutex timestamp failed to be retrieve, rather than retrieved successfully.