### PR TITLE
Fail seed for any unhandled exception and restart the whole seed process

### DIFF
--- a/Services/Seed.cs
+++ b/Services/Seed.cs
@@ -147,51 +147,30 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services
 
             foreach (var group in template.Groups)
             {
-                try
-                {
-                    await this.storage.UpdateDeviceGroupAsync(group.Id, group, "*");
-                }
-                catch (Exception ex)
-                {
-                    this.log.Error($"Failed to seed default group {group.DisplayName}", () => new { group, ex.Message });
-                }
+                await this.storage.UpdateDeviceGroupAsync(group.Id, group, "*");
             }
 
             foreach (var rule in template.Rules)
             {
-                try
-                {
-                    await this.telemetryClient.UpdateRuleAsync(rule, "*");
-                }
-                catch (Exception ex)
-                {
-                    this.log.Error($"Failed to seed default rule {rule.Description}", () => new { rule, ex.Message });
-                }
+                await this.telemetryClient.UpdateRuleAsync(rule, "*");
             }
 
-            try
+            var simulationModel = await this.simulationClient.GetSimulationAsync();
+
+            if (simulationModel != null)
             {
-                var simulationModel = await this.simulationClient.GetSimulationAsync();
-
-                if (simulationModel != null)
-                {
-                    this.log.Info("Skip seed simulation since there is already one simuation", () => new { simulationModel });
-                }
-                else
-                {
-                    simulationModel = new SimulationApiModel
-                    {
-                        Id = "1",
-                        Etag = "*"
-                    };
-
-                    simulationModel.DeviceModels = template.DeviceModels.ToList();
-                    await this.simulationClient.UpdateSimulation(simulationModel);
-                }
+                this.log.Info("Skip seed simulation since there is already one simulation", () => new { simulationModel });
             }
-            catch (Exception ex)
+            else
             {
-                this.log.Error("Failed to seed default simulation", () => new { ex.Message });
+                simulationModel = new SimulationApiModel
+                {
+                    Id = "1",
+                    Etag = "*",
+                    DeviceModels = template.DeviceModels.ToList()
+                };
+
+                await this.simulationClient.UpdateSimulation(simulationModel);
             }
         }
     }

--- a/Services/Seed.cs
+++ b/Services/Seed.cs
@@ -147,14 +147,17 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services
 
             foreach (var group in template.Groups)
             {
+                this.log.Info("Creating seed device group", () => group);
                 await this.storage.UpdateDeviceGroupAsync(group.Id, group, "*");
             }
 
             foreach (var rule in template.Rules)
             {
+                this.log.Info("Creating seed rule", () => rule);
                 await this.telemetryClient.UpdateRuleAsync(rule, "*");
             }
 
+            this.log.Info("Checking for whether simulation seed data already exists", () => { });
             var simulationModel = await this.simulationClient.GetSimulationAsync();
 
             if (simulationModel != null)
@@ -163,6 +166,8 @@ namespace Microsoft.Azure.IoTSolutions.UIConfig.Services
             }
             else
             {
+                this.log.Info("Simulation seed data does not exist, attempting to create it", () => { });
+
                 simulationModel = new SimulationApiModel
                 {
                     Id = "1",


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
In this code change, we are going to avoid partial seed state by treating the seed process failed for any unhandled exception, and restarting the whole seed process.

Since the seeding operation of device group and rule are idempotent (using PUT verb), re-seed will not introduce issue. On the other hand, we checked the existence of simulation to avoid submit multiple simulations.

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
