### PR TITLE
Updating the default rules

### DIFF
--- a/Services/Data/default.json
+++ b/Services/Data/default.json
@@ -75,7 +75,7 @@
         {
           "Field": "pressure",
           "Operator": "GreaterThan",
-          "Value": "250"
+          "Value": "298"
         }
       ]
     },
@@ -93,23 +93,6 @@
           "Field": "temperature",
           "Operator": "GreaterThan",
           "Value": "80"
-        }
-      ]
-    },
-    {
-      "Id": "default_Engine_Fuel_Empty",
-      "Name": "Engine tank empty",
-      "Enabled": true,
-      "Description": "Fuel level is less than 5",
-      "GroupId": "default_Engines",
-      "Severity": "Info",
-      "Calculation": "Instant",
-      "TimePeriod": "00:00:00",
-      "Conditions": [
-        {
-          "Field": "fuellevel",
-          "Operator": "LessThan",
-          "Value": "5"
         }
       ]
     },


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
* Lot of alerts are being generated for instant rules that can throttle documentdb
* Increasing the value for temperature to highest possible where we will still get alerts but not as many
* Also removing the empty tank default rule since engine-02 is always empty which means we get as many alerts as messages

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
