### PR TITLE
Before build, detect whether secrets are available

### DIFF
--- a/scripts/env-vars-check
+++ b/scripts/env-vars-check
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+# Before checking all the env vars, detect whether secrets, usually encrypted, are available or not.
+# Secrets are not available when building a pull request, so the script will not check for those.
+detect_secrets() {
+    SECRETS_AVAILABLE="true"
+    if [[ "$TRAVIS_PULL_REQUEST" != "" && "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+        SECRETS_AVAILABLE="false"
+        echo "Warning: secrets and encrypted variables are not available when testing pull requests."
+    fi
+}
+
+detect_secrets
+
 if [[ -z "$PCS_STORAGEADAPTER_WEBSERVICE_URL" ]]; then
     echo "Error: the PCS_STORAGEADAPTER_WEBSERVICE_URL environment variable is not defined."
     exit -1
@@ -19,7 +31,7 @@ if [[ -z "$PCS_IOTHUBMANAGER_WEBSERVICE_URL" ]]; then
     echo "Error: the PCS_IOTHUBMANAGER_WEBSERVICE_URL environment variable is not defined."
     exit -1
 fi
-if [[ -z "$PCS_AZUREMAPS_KEY" ]]; then
+if [[ -z "$PCS_AZUREMAPS_KEY" && "$SECRETS_AVAILABLE" = "true" ]]; then
     echo "Error: the PCS_AZUREMAPS_KEY environment variable is not defined."
     exit -1
 fi


### PR DESCRIPTION
Before checking all the env vars, detect whether secrets, usually encrypted, are available or not. Secrets are not available when building a pull request, so the script will not check for those.

# Description and Motivation <!-- Info & Context so we can review your pull request -->

Before checking all the env vars, detect whether secrets, usually encrypted, are available or not. Secrets are not available when building a pull request, so the script will not check for those.

This change allows the build to run for pull requests, e.g. unit tests can be executed. 
Functional tests requiring secrets won't work.

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly