### PR TITLE
Bug 2753717

### DIFF
--- a/Services/Data/default.json
+++ b/Services/Data/default.json
@@ -5,7 +5,7 @@
       "DisplayName": "Chillers",
       "Conditions": [
         {
-          "Key": "properties.reported.Type",
+          "Key": "Properties.Reported.Type",
           "Operator": "EQ",
           "Value": "Chiller"
         }
@@ -16,7 +16,7 @@
       "DisplayName": "Prototyping devices",
       "Conditions": [
         {
-          "Key": "properties.reported.Type",
+          "Key": "Properties.Reported.Type",
           "Operator": "EQ",
           "Value": "Prototyping"
         }
@@ -27,7 +27,7 @@
       "DisplayName": "Engines",
       "Conditions": [
         {
-          "Key": "properties.reported.Type",
+          "Key": "Properties.Reported.Type",
           "Operator": "EQ",
           "Value": "Engine"
         }
@@ -38,7 +38,7 @@
       "DisplayName": "Trucks",
       "Conditions": [
         {
-          "Key": "properties.reported.Type",
+          "Key": "Properties.Reported.Type",
           "Operator": "EQ",
           "Value": "Truck"
         }
@@ -49,7 +49,7 @@
       "DisplayName": "Elevators",
       "Conditions": [
         {
-          "Key": "properties.reported.Type",
+          "Key": "Properties.Reported.Type",
           "Operator": "EQ",
           "Value": "Elevator"
         }


### PR DESCRIPTION
Fix capitalization in service data default.json file

# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

Fix a regression bug after cache changes which changed the values of deviceProperties to be in PascalCase, but forgot to update hardcoded values in PCS-Config seed-data
Expected - Properties.Reported.Type  Actual - properties.reported.Type
So, the field dropdown isn't able to bind the input value.

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
